### PR TITLE
fix type error in Wordcount

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     }
   ],
   "require": {
-    "php": ">=7.2",
+    "php": ">=8.2",
     "ext-intl": "*"
   },
   "autoload": {

--- a/src/Sylae/Wordcount.php
+++ b/src/Sylae/Wordcount.php
@@ -46,7 +46,7 @@ class Wordcount
 
         $last = null;
         $wc = 0;
-        foreach (preg_split('//u', $text, null, PREG_SPLIT_NO_EMPTY) as $char) {
+        foreach (preg_split('//u', $text, flags: PREG_SPLIT_NO_EMPTY) as $char) {
             $isLetter = self::isLetter(IntlChar::ord($char));
             if ($last !== $isLetter && $isLetter) {
                 $wc++;


### PR DESCRIPTION
PHP 8.3 does not accept `null` to the limit parameter

Fix #3